### PR TITLE
fix: convert `idx` type from `i64` to `u64`

### DIFF
--- a/src/tokens/referenced_token.rs
+++ b/src/tokens/referenced_token.rs
@@ -65,6 +65,6 @@ pub struct StatusClaim {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReferencedStatusList {
-    pub idx: i64,
+    pub idx: u64,
     pub uri: Url,
 }


### PR DESCRIPTION
# Description of change
> idx: REQUIRED.  The idx (index) claim MUST specify an
            Integer that represents the index to check for status
            information in the Status List for the current Referenced
            Token.  The value of idx MUST be **a non-negative number**,
            containing a value of zero or greater.

## Links to any relevant issues
n/a

## How the change has been tested
Describe the tests that you ran to verify your changes.
Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes